### PR TITLE
Add a new ignoreHTTPSErrors flag on CLI args and in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ projectName: YOUR_PROJECT_NAME
 samples: 3
 distant: false
 useAdblock: true
+ignoreHTTPSErrors: true
 containers:
   - "CONTAINER_NAME"
   - "ANOTHER_CONTAINER_NAME"
@@ -241,8 +242,8 @@ Create an analysis on GreenFrame server.
 ```
 USAGE
   $ greenframe analyze [BASEURL] [SCENARIO] [-C <value>] [-K <value>] [-t <value>] [-p <value>] [-c <value>]
-    [--commitId <value>] [-b <value>] [-s <value>] [-d] [-a] [--dockerdHost <value>] [--dockerdPort <value>]
-    [--containers <value>] [--databaseContainers <value>]
+    [--commitId <value>] [-b <value>] [-s <value>] [-d] [-a] [-i] [--dockerdHost <value>]
+    [--dockerdPort <value>] [--containers <value>] [--databaseContainers <value>]
 
 ARGUMENTS
   BASEURL   Your baseURL website
@@ -255,6 +256,7 @@ FLAGS
   -b, --branchName=<value>      Pass branch name manually
   -c, --commitMessage=<value>   Pass commit message manually
   -d, --distant                 Run a distant analysis on GreenFrame Server instead of locally
+  -i, --ignoreHTTPSErrors       Ignore HTTPS errors during analysis
   -p, --projectName=<value>     Project name
   -s, --samples=<value>         Number of runs done for the score computation
   -t, --threshold=<value>       Consumption threshold
@@ -299,7 +301,7 @@ Open browser to develop your GreenFrame scenario
 
 ```
 USAGE
-  $ greenframe open [BASEURL] [SCENARIO] [-C <value>] [-a]
+  $ greenframe open [BASEURL] [SCENARIO] [-C <value>] [-a] [--ignoreHTTPSErrors]
 
 ARGUMENTS
   BASEURL   Your baseURL website
@@ -308,6 +310,7 @@ ARGUMENTS
 FLAGS
   -C, --configFile=<value>  Path to config file
   -a, --useAdblock          Use an adblocker during analysis
+  --ignoreHTTPSErrors       Ignore HTTPS errors during analysis
 
 DESCRIPTION
   Open browser to develop your GreenFrame scenario

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -38,6 +38,7 @@ class AnalyzeCommand extends Command {
         samples: DEFAULT_SAMPLES,
         distant: false,
         useAdblock: false,
+        ignoreHTTPSErrors: false,
     };
 
     static flags = {
@@ -81,6 +82,10 @@ class AnalyzeCommand extends Command {
         useAdblock: Flags.boolean({
             char: 'a',
             description: 'Use an adblocker during analysis',
+        }),
+        ignoreHTTPSErrors: Flags.boolean({
+            char: 'i',
+            description: 'Ignore HTTPS errors during analysis',
         }),
         dockerdHost: Flags.string({
             description: 'Docker daemon host',

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -22,6 +22,7 @@ class OpenCommand extends Command {
     static defaultFlags = {
         configFile: './.greenframe.yml',
         useAdblock: false,
+        ignoreHTTPSErrors: false,
     };
 
     static flags = {
@@ -33,6 +34,9 @@ class OpenCommand extends Command {
         useAdblock: Flags.boolean({
             char: 'a',
             description: 'Use an adblocker during analysis',
+        }),
+        ignoreHTTPSErrors: Flags.boolean({
+            description: 'Ignore HTTPS errors during analysis',
         }),
     };
 
@@ -61,6 +65,7 @@ class OpenCommand extends Command {
                     executablePath,
                     useAdblock: flags.useAdblock,
                     extraHosts: args.extraHosts,
+                    ignoreHTTPSErrors: flags.ignoreHTTPSErrors,
                 });
                 console.info(
                     `✅ ${scenario.name}: ${

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -11,6 +11,7 @@ const executeScenario = require('./scenarioWrapper');
             hostIP: process.env.HOSTIP,
             extraHosts: process.env.EXTRA_HOSTS ? process.env.EXTRA_HOSTS.split(',') : [],
             useAdblock: args.useAdblock,
+            ignoreHTTPSErrors: args.ignoreHTTPSErrors,
         }
     );
     console.log('=====TIMELINES=====');

--- a/src/runner/scenarioWrapper.js
+++ b/src/runner/scenarioWrapper.js
@@ -41,6 +41,7 @@ const executeScenario = async (scenario, options = {}) => {
     const context = await browser.newContext({
         userAgent:
             'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.105 Safari/537.36',
+        ignoreHTTPSErrors: options.ignoreHTTPSErrors,
     });
 
     context.setDefaultTimeout(60_000);

--- a/src/services/container/execScenarioContainer.js
+++ b/src/services/container/execScenarioContainer.js
@@ -41,7 +41,11 @@ const startContainer = async () => {
     return 'OK';
 };
 
-const execScenarioContainer = async (scenario, url, { useAdblock } = {}) => {
+const execScenarioContainer = async (
+    scenario,
+    url,
+    { useAdblock, ignoreHTTPSErrors } = {}
+) => {
     try {
         let command = `docker exec ${CONTAINER_DEVICE_NAME} node /greenframe/dist/runner/index.js --scenario="${encodeURIComponent(
             scenario
@@ -49,6 +53,10 @@ const execScenarioContainer = async (scenario, url, { useAdblock } = {}) => {
 
         if (useAdblock) {
             command += ` --useAdblock`;
+        }
+
+        if (ignoreHTTPSErrors) {
+            command += ` --ignoreHTTPSErrors`;
         }
 
         const { stdout, stderr } = await exec(command);

--- a/src/services/container/index.ts
+++ b/src/services/container/index.ts
@@ -35,6 +35,7 @@ export const executeScenarioAndGetContainerStats = async ({
     url,
     samples = DEFAULT_SAMPLES,
     useAdblock,
+    ignoreHTTPSErrors,
     containers = [],
     databaseContainers = [],
     kubeContainers = [],
@@ -47,6 +48,7 @@ export const executeScenarioAndGetContainerStats = async ({
     url: string;
     samples?: number;
     useAdblock?: boolean;
+    ignoreHTTPSErrors?: boolean;
     containers?: string[] | string;
     databaseContainers?: string[] | string;
     kubeContainers?: string[];
@@ -128,6 +130,7 @@ export const executeScenarioAndGetContainerStats = async ({
 
             const { timelines, milestones } = await execScenarioContainer(scenario, url, {
                 useAdblock,
+                ignoreHTTPSErrors,
             });
 
             allMilestones.push(milestones);

--- a/src/services/parseConfigFile.js
+++ b/src/services/parseConfigFile.js
@@ -27,6 +27,7 @@ const parseConfigFile = async (path) => {
                 kubeConfig,
                 dockerdHost,
                 dockerdPort,
+                ignoreHTTPSErrors,
             } = yaml.load(file);
             return {
                 args: {
@@ -48,6 +49,7 @@ const parseConfigFile = async (path) => {
                     kubeConfig,
                     dockerdHost,
                     dockerdPort,
+                    ignoreHTTPSErrors,
                 },
             };
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export type Analysis = {
     samples: any[];
     distant: boolean;
     useAdblock: boolean;
+    ignoreHTTPSErrors: boolean;
     projectName: string;
     gitInfos: {
         branchName: string;


### PR DESCRIPTION
Add a flag for greenframe-browser to be able to ignore HTTPS errors so that it can run locally with certificate errors.