### PR TITLE
Change getBranchName function to match with orphan checkouts

### DIFF
--- a/src/services/git/__tests__/utils.js
+++ b/src/services/git/__tests__/utils.js
@@ -32,10 +32,10 @@ describe('#getCommitMessage', () => {
 describe('#getBranchName', () => {
     it('Should call exec', async () => {
         exec.mockReturnValue({ stdout: 'BRANCH NAME' });
-        const commitMessage = await getBranchName();
+        const branchMessage = await getBranchName();
         expect(exec).toHaveBeenCalledTimes(1);
-        expect(exec).toHaveBeenCalledWith('git rev-parse --abbrev-ref HEAD');
-        expect(commitMessage).toBe('BRANCH NAME');
+        expect(exec).toHaveBeenCalledWith('git branch --show-current');
+        expect(branchMessage).toBe('BRANCH NAME');
     });
     afterEach(() => {
         exec.mockClear();

--- a/src/services/git/utils.js
+++ b/src/services/git/utils.js
@@ -2,8 +2,13 @@ const util = require('node:util');
 const exec = util.promisify(require('node:child_process').exec);
 
 const getCommitMessage = async () => {
-    const { stdout } = await exec('git log -1 --pretty=%B');
-    return stdout.trim();
+    try {
+        const { stdout } = await exec('git log -1 --pretty=%B');
+        return stdout.trim();
+    } catch (error) {
+        console.warn('getCommitMessage:', error.message);
+        return 'defaultAnalyseName';
+    }
 };
 
 const getBranchName = async () => {
@@ -13,9 +18,13 @@ const getBranchName = async () => {
 };
 
 const getCommitId = async () => {
-    const { stdout } = await exec('git rev-parse HEAD');
-
-    return stdout.trim();
+    try {
+        const { stdout } = await exec('git rev-parse HEAD');
+        return stdout.trim();
+    } catch (error) {
+        console.warn('getCommitId:', error.message);
+        return 'empty-----------------------------------';
+    }
 };
 
 const getDirectCommitAncestor = async () => {

--- a/src/services/git/utils.js
+++ b/src/services/git/utils.js
@@ -7,7 +7,7 @@ const getCommitMessage = async () => {
 };
 
 const getBranchName = async () => {
-    const { stdout } = await exec('git rev-parse --abbrev-ref HEAD');
+    const { stdout } = await exec('git branch --show-current');
 
     return stdout.trim();
 };


### PR DESCRIPTION
Trello card [#677](https://trello.com/c/naN6o2BF/677-fix-getbranchname-in-greenframe-cli)

The previous command `git rev-parse --abbrev-ref HEAD` can't give the name of a branch when it's an orphan.
It always give `HEAD` instead

With the new command, we always get the real branch name
`git branch --show-current`

![image](https://github.com/marmelab/greenframe-cli/assets/39904906/16a20550-aad1-441c-9bdf-1c0c338de411)
