### PR TITLE
update_README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,7 @@ You can run a custom scenario instead of the "visit" scenario by passing a scena
 $ greenframe analyze https://marmelab.com ./my-scenario.js
 ```
 
-GreenFrame uses [PlayWright](https://playwright.dev/) to run scenarios. A custom PlayWright scenario looks like the following:
-
-```js
-// in my-scenario.js
-const scenario = async (page) => {
-    await page.goto('', { waitUntil: 'networkidle' }); // Go to the baseUrl
-    await page.waitForTimeout(3000); // Wait for 3 seconds
-    await page.scrollToElement('footer'); // Scroll to the footer (if present)
-    await page.waitForNetworkIdle(); // Wait every request has been answered as a normal user.
-};
-
-module.exports = scenario;
-```
+GreenFrame uses [PlayWright](https://playwright.dev/) to run scenarios. To discover what a custom PlayWright scenario looks alike, you can refer to our [documentation](https://docs.greenframe.io/scenario/).
 
 Check [the PlayWright documentation on writing tests](https://playwright.dev/docs/writing-tests) for more information.
 


### PR DESCRIPTION
## Problem
There is a confusion in the README. There is an example of a GreenFrame script, but it corresponding to an future version of greenframe-cli.

## Solution 
Change this file to link the official GreenFrame documentation.

**Before** 
![image](https://github.com/marmelab/greenframe-cli/assets/131013150/13e993ed-a86c-4d6d-950f-0a3446d76d82)

**Now**
![image](https://github.com/marmelab/greenframe-cli/assets/131013150/2b2f3b58-5924-4498-8351-c7b92f9144ad)
