### PR TITLE
fix: replace grep -P commands - Closes #83 #63

### DIFF
--- a/src/bash/getHostIP.sh
+++ b/src/bash/getHostIP.sh
@@ -5,9 +5,9 @@ if command -v ip 1> /dev/null;
 then
     if ip -4 addr show docker0 > /dev/null 2>&1 # Docker0 is network for docker under linux and OSX
     then
-        printf $(ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+        printf $(ip -4 addr show docker0 | grep -oE '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | head -1)
     else
-        printf $(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}') # eth0 is network for docker under wsl
+        printf $(ip -4 addr show eth0 | grep -oE '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | head -1) # eth0 is network for docker under wsl
     fi
 else
     printf $(ifconfig | grep 'inet ' | grep -v 127.0.0.1  | awk '{ print $2 }' | head -1 | sed -n 's/[^0-9]*\([0-9\.]*\)/\1/p')


### PR DESCRIPTION
Change `grep -P` command witch is not reconized on every macOS

- `grep -P` -> `grep -E`

Closes #83 #63 

This was tested on Ubuntu 24.04 and macOS 13.0.1