### PR TITLE
Display per container detailed scores.

### DIFF
--- a/src/tasks/displayAnalysisResult.js
+++ b/src/tasks/displayAnalysisResult.js
@@ -20,6 +20,29 @@ const formatTotal = (total, unit) => {
     return `${computeTotalMetric(total)} ${unit}`;
 };
 
+const toBytes = (metrics) =>
+    Object.fromEntries(
+        Object.entries(metrics).map(([key, value]) => [
+            key,
+            Math.round(value * 1024 ** 3),
+        ])
+    );
+const toPrecision = (metrics, precision) =>
+    Object.fromEntries(
+        Object.entries(metrics).map(([key, value]) => [key, value.toPrecision(precision)])
+    );
+const withUnits = (metrics) =>
+    Object.fromEntries(
+        Object.entries(metrics).map(([key, value], i) => [
+            key + (i < 3 ? ' (s)' : ' (B)'),
+            value,
+        ])
+    );
+const withWh = (metrics) =>
+    Object.fromEntries(
+        Object.entries(metrics).map(([key, value]) => [`${key} (Wh)`, value])
+    );
+
 const displayAnalysisResults = (result, isFree) => {
     console.info('\nAnalysis complete !\n');
     console.info('Result summary:');
@@ -35,6 +58,25 @@ const displayAnalysisResults = (result, isFree) => {
 
         if (scenario.status === STATUS.FINISHED) {
             console.info(`✅ ${scenario.name} completed`);
+
+            console.info('\nMEASUREMENTS');
+            const measurements = Object.fromEntries(
+                scenario.containers.map(({ name, score }) => [
+                    name,
+                    withUnits(toPrecision({ ...score.s, ...toBytes(score.gb) }, 3)),
+                ])
+            );
+            console.table(measurements);
+
+            console.info('\nESTIMATES');
+            const estimates = Object.fromEntries(
+                scenario.containers.map(({ name, score }) => [
+                    name,
+                    withWh(toPrecision(score.wh, 2)),
+                ])
+            );
+            console.table(estimates);
+
             if (scenario.threshold) {
                 console.info(
                     `The estimated footprint at ${totalCo2} eq. co2 ± ${precision}% (${totalMWh}) is under the limit configured at ${scenario.threshold} g eq. co2.`


### PR DESCRIPTION
Hello,

As you may know, I am a great fan of *GreenFrame*, and I use it with my students in a course dedicated to "Reducing environmental footprint of digital services" (see [UTT-GL03](https://github.com/UTT-GL03)). *GreenFrame CLI* and *APP* were used it in the second part of students' projects (see [example](https://github.com/UTT-GL03/QVOTIDIE/tree/7e91959e58dc9c438de22c357c4d6106cd9a37a5?tab=readme-ov-file#prototype-n2--fonctionnalités-pour-le-scénario-prioritaire-avec-données-statiques-chargées-de-manière-dynamique)). As you may see we relied a bit on graphics but especially on detailed scores by container and by scenario.

The following commit restores in *GreenFrame CLI* per container and per scenario detailed scores (once present in *GreenFrame APP*).

Here is an example of the output with 2 scenarios and 3 service containers:

<img width="1520" height="1702" alt="Capture d’écran 2025-10-29 à 14 50 01" src="https://github.com/user-attachments/assets/54d31670-2b27-44ca-aa93-5974e6e7fb8d" />

I hope you will find it useful.

Regards.